### PR TITLE
Add support for Elastic Beats 5.0-RC

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,7 +77,7 @@ elasticbeats__output_defaults:
 elasticbeats__logging_defaults:
   to_syslog: true
                                                                    # ]]]
-# .. envvar:: elasticbeats__protocol_defaults
+# .. envvar:: elasticbeats__protocol_defaults [[[
 #
 # Default protocol definitions for Packetbeat.
 elasticbeats__protocol_defaults:
@@ -102,6 +102,13 @@ elasticbeats__protocol_defaults:
 # Packages and installation [[[
 # -----------------------------
 
+# .. envvar:: elasticbeats__version [[[
+#
+# Release version of Elastic Beats. Check (and/or extend)
+# :envvar:`elasticbeats__apt_repo_map` for the list of supported versions.
+elasticbeats__version: '1.3'
+
+                                                                   # ]]]
 # .. envvar:: elasticbeats__deploy_state [[[
 #
 # What is the desired state which this role should achieve? Possible options:
@@ -119,12 +126,20 @@ elasticbeats__protocol_defaults:
 elasticbeats__deploy_state: 'present'
 
                                                                    # ]]]
+# .. envvar:: elasticbeats__apt_repo_map [[[
+#
+# Dictionary to lookup upstream repository URLs for a corresponding release.
+elasticbeats__apt_repo_map:
+  '1.3': 'https://packages.elastic.co/beats/apt'
+  '5.0-pre': 'https://artifacts.elastic.co/packages/5.x-prerelease/apt'
+
+                                                                   # ]]]
 # .. envvar:: elasticbeats__apt_repo_source [[[
 #
 # APT ``source.list`` configuration string of the Beats ``.deb.`` repository.
 # Set to ``False`` if the repository providing the Beats packages is
 # configured through other means.
-elasticbeats__apt_repo_source: 'deb https://packages.elastic.co/beats/apt stable main'
+elasticbeats__apt_repo_source: 'deb {{ elasticbeats__apt_repo_map[elasticbeats__version] }} stable main'
 
                                                                    # ]]]
 # .. envvar:: elasticbeats__apt_repo_key_id [[[
@@ -133,5 +148,6 @@ elasticbeats__apt_repo_source: 'deb https://packages.elastic.co/beats/apt stable
 # provided through other means or the packages are not signed.
 elasticbeats__apt_repo_key_id: '4609 5ACC 8548 582C 1A26 99A9 D27D 666C D88E 42B4'
 
+                                                                   # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ elasticbeats__beats_defaults:
       shipper: {}
       logging: '{{ elasticbeats__logging_defaults }}'
 
+  # only used in Beats 3.x
   - name: 'topbeat'
     config:
       input:
@@ -51,6 +52,24 @@ elasticbeats__beats_defaults:
           cpu_per_core: false
       output: '{{ elasticbeats__output_defaults }}'
       shipper: {}
+      logging: '{{ elasticbeats__logging_defaults }}'
+
+  # only used in Beats 5.x
+  - name: 'metricbeat'
+    config:
+      metricbeat.modules:
+        - module: system
+          metricsets:
+            - cpu
+            - load
+            - filesystem
+            - memory
+            - network
+            - process
+          enabled: true
+          period: 10s
+          processes: [".*"]
+      output: '{{ elasticbeats__output_defaults }}'
       logging: '{{ elasticbeats__logging_defaults }}'
 
   - name: 'packetbeat'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,6 +10,11 @@
     name: 'topbeat'
     state: 'restarted'
 
+- name: Restart Metricbeat
+  service:
+    name: 'metricbeat'
+    state: 'restarted'
+
 - name: Restart Packetbeat
   service:
     name: 'packetbeat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,8 +40,8 @@
   args:
     creates: '{{ item.0 }}/{{ item.1 }}.dpkg-divert'
   with_together:
-    - '{{ lookup("template", "lookup/elasticbeats__configdirs.j2") }}'
-    - '{{ lookup("template", "lookup/elasticbeats__configfiles.j2") }}'
+    - '{{ lookup("template", "lookup/elasticbeats__configdirs.j2") | from_yaml }}'
+    - '{{ lookup("template", "lookup/elasticbeats__configfiles.j2") | from_yaml }}'
 
 - name: Configure Beats services
   template:
@@ -54,14 +54,14 @@
   notify:
     - 'Restart {{ item.3 | title }}'
   with_together:
-    - '{{ lookup("template", "lookup/elasticbeats__configdirs.j2") }}'
-    - '{{ lookup("template", "lookup/elasticbeats__configfiles.j2") }}'
-    - '{{ lookup("template", "lookup/elasticbeats__exec.j2") }}'
-    - '{{ lookup("template", "lookup/elasticbeats__services.j2") }}'
+    - '{{ lookup("template", "lookup/elasticbeats__configdirs.j2") | from_yaml }}'
+    - '{{ lookup("template", "lookup/elasticbeats__configfiles.j2") | from_yaml }}'
+    - '{{ lookup("template", "lookup/elasticbeats__exec.j2") | from_yaml }}'
+    - '{{ lookup("template", "lookup/elasticbeats__services.j2") | from_yaml }}'
 
 - name: Ensure Beat services are in the desired state
   service:
     name: '{{ item }}'
     state: 'started'
     enabled: True
-  with_items: '{{ lookup("template", "lookup/elasticbeats__services.j2") }}'
+  with_items: '{{ lookup("template", "lookup/elasticbeats__services.j2") | from_yaml }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Ensure specified packages are in there desired state
   package:
     name: '{{ item }}'
-    state: 'present'
+    state: '{{ elasticbeats__deploy_state }}'
   with_flattened: '{{ lookup("template", "lookup/elasticbeats__packages.j2") | from_yaml }}'
 
 - name: Divert original config
@@ -52,10 +52,11 @@
     mode: '0640'
     validate: '{{ item.2 }} -c %s -configtest'
   notify:
-    - 'Restart {{ item.2 | title }}'
+    - 'Restart {{ item.3 | title }}'
   with_together:
     - '{{ lookup("template", "lookup/elasticbeats__configdirs.j2") }}'
     - '{{ lookup("template", "lookup/elasticbeats__configfiles.j2") }}'
+    - '{{ lookup("template", "lookup/elasticbeats__exec.j2") }}'
     - '{{ lookup("template", "lookup/elasticbeats__services.j2") }}'
 
 - name: Ensure Beat services are in the desired state

--- a/templates/etc/filebeat/filebeat.yml.j2
+++ b/templates/etc/filebeat/filebeat.yml.j2
@@ -12,7 +12,11 @@
 {%   if _beat['name'] == 'filebeat' %}
 {%     for _section in [ 'filebeat', 'output', 'shipper', 'logging' ] %}
 {%       if _section in _beat %}
-{%         set _ = _config.update({_section: (_config[_section] | combine(_beat['config'][_section], recursive=True))}) %}
+{%         if _section in _config %}
+{%           set _ = _config.update({_section: (_config[_section] | combine(_beat['config'][_section], recursive=True))}) %}
+{%         else %}
+{%           set _ = _config.update({_section: _beat['config'][_section]}) %}
+{%         endif %}
 {%       endif %}
 {%     endfor %}
 {%   endif %}

--- a/templates/etc/metricbeat/metricbeat.yml.j2
+++ b/templates/etc/metricbeat/metricbeat.yml.j2
@@ -1,0 +1,32 @@
+{#
+ # First set default configuration from elasticbeats__beats_defaults
+ #}
+{% set _config = {} %}
+{% for _default in elasticbeats__beats_defaults %}
+{%   if _default['name'] == 'metricbeat' %}
+{%     if 'config' in _default %}
+{%       for _key in _default['config'] %}
+{%         set _ = _config.update({_key: _default['config'][_key]}) %}
+{%       endfor %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{#
+ #  Overwrite defaults with user configuration
+ #}
+{% for _beat in elasticbeats__beats|d([]) %}
+{%   if _beat['name'] == 'metricbeat' %}
+{%     if 'config' in _beat %}
+{%       for _key in _beat['config'] %}
+{%         if _key in _config and _config[_key] is mapping %}
+{%           set _ = _config.update({_key: (_config[_key] | combine(_beat['config'][_key], recursive=True))}) %}
+{%         else %}
+{%           set _ = _config.update({_key: _beat['config'][_key]}) %}
+{%         endif %}
+{%       endfor %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+# {{ ansible_managed }}
+
+{{ _config | to_nice_yaml }}

--- a/templates/etc/packetbeat/packetbeat.yml.j2
+++ b/templates/etc/packetbeat/packetbeat.yml.j2
@@ -1,7 +1,7 @@
 {% set _config = {} %}
 {% for _default in elasticbeats__beats_defaults %}
 {%   if _default['name'] == 'packetbeat' %}
-{%     for _section in [ 'interfaces', 'protocols', 'output', 'shipper', 'logging' ] %}
+{%     for _section in [ 'interfaces', 'packetbeat.interfaces', 'protocols', 'packetbeat.protocols', 'output', 'shipper', 'logging' ] %}
 {%       if 'config' in _default and _section in _default['config'] %}
 {%         set _ = _config.update({_section: _default['config'][_section]|d({})}) %}
 {%       endif %}
@@ -10,13 +10,32 @@
 {% endfor %}
 {% for _beat in elasticbeats__beats|d([]) %}
 {%   if _beat['name'] == 'packetbeat' %}
-{%     for _section in [ 'interfaces', 'protocols', 'output', 'shipper', 'logging' ] %}
+{%     for _section in [ 'interfaces', 'packetbeat.interfaces', 'protocols', 'packetbeat.protocols', 'output', 'shipper', 'logging' ] %}
 {%       if _section in _beat %}
 {%         set _ = _config.update({_section: (_config[_section] | combine(_beat['config'][_section], recursive=True))}) %}
 {%       endif %}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
+{#
+ #  Migate configuration to Beats 5.x
+ #}
+{% if elasticbeats__version | version_compare('5.0-pre', '>=') %}
+{%   for _deprecated in [ 'interfaces', 'protocols' ] %}
+{%     if _deprecated in _config %}
+{%       set _migrated = 'packetbeat.' + _deprecated %}
+{%       if not _migrated in _config %}
+{%         set _ = _config.update({_migrated: _config[_deprecated]}) %}
+{%         set _ = _config.pop(_deprecated) %}
+{%       endif %}
+{%     endif %}
+{%   endfor %}
+{%   for _shipper in _config['shipper'] %}
+{%     set _ = _config.update(_shipper) %}
+{%     set _ = _config['shipper'].pop(_shipper) %}
+{%   endfor %}
+{%   set _ = _config.pop('shipper') %}
+{% endif %}
 # {{ ansible_managed }}
 
 {{ _config | to_nice_yaml }}

--- a/templates/etc/packetbeat/packetbeat.yml.j2
+++ b/templates/etc/packetbeat/packetbeat.yml.j2
@@ -1,20 +1,41 @@
+{#
+ # First set default configuration from elasticbeats__beats_defaults
+ #}
 {% set _config = {} %}
-{% for _default in elasticbeats__beats_defaults %}
-{%   if _default['name'] == 'packetbeat' %}
-{%     for _section in [ 'interfaces', 'packetbeat.interfaces', 'protocols', 'packetbeat.protocols', 'output', 'shipper', 'logging' ] %}
-{%       if 'config' in _default and _section in _default['config'] %}
-{%         set _ = _config.update({_section: _default['config'][_section]|d({})}) %}
-{%       endif %}
-{%     endfor %}
+{% for _default in elasticbeats__beats_defaults|d([]) %}
+{%   if _default['name'] == 'packetbeat' and 'config' in _default %}
+{#
+ #  Only copy valid configuration keys for Beats 3.x
+ #}
+{%     if elasticbeats__version | version_compare('5.0-pre', '<') %}
+{%       for _section in [ 'interfaces', 'protocols', 'output', 'shipper', 'logging' ] %}
+{%         if _section in _default['config'] %}
+{%           set _ = _config.update({_section: _default['config'][_section]}) %}
+{%         endif %}
+{%       endfor %}
+{%     else %}
+{%       for _key in _default['config'] %}
+{%         set _ = _config.update({_key: _default['config'][_key]}) %}
+{%       endfor %}
+{%     endif %}
 {%   endif %}
 {% endfor %}
+{#
+ #  Overwrite defaults with user configuration
+ #}
 {% for _beat in elasticbeats__beats|d([]) %}
-{%   if _beat['name'] == 'packetbeat' %}
-{%     for _section in [ 'interfaces', 'packetbeat.interfaces', 'protocols', 'packetbeat.protocols', 'output', 'shipper', 'logging' ] %}
-{%       if _section in _beat %}
-{%         set _ = _config.update({_section: (_config[_section] | combine(_beat['config'][_section], recursive=True))}) %}
-{%       endif %}
-{%     endfor %}
+{%   if _beat['name'] == 'packetbeat' and 'config' in _beat %}
+{%     if elasticbeats__version | version_compare('5.0-pre', '<') %}
+{%       for _section in [ 'interfaces', 'protocols', 'output', 'shipper', 'logging' ] %}
+{%         if _section in _beat['config'] %}
+{%           set _ = _config.update({_section: (_config[_section] | combine(_beat['config'][_section], recursive=True))}) %}
+{%         endif %}
+{%       endfor %}
+{%     else %}
+{%       for _key in _beat['config'] %}
+{%         set _ = _config.update({_key: (_config[_key] | combine(_beat['config'][_key], recursive=True))}) %}
+{%       endfor %}
+{%     endif %}
 {%   endif %}
 {% endfor %}
 {#
@@ -23,9 +44,31 @@
 {% if elasticbeats__version | version_compare('5.0-pre', '>=') %}
 {%   for _deprecated in [ 'interfaces', 'protocols' ] %}
 {%     if _deprecated in _config %}
-{%       set _migrated = 'packetbeat.' + _deprecated %}
-{%       if not _migrated in _config %}
-{%         set _ = _config.update({_migrated: _config[_deprecated]}) %}
+{#
+ # Check each key if it is already set via new syntax; if so, drop the old
+ # value, otherwise convert to new syntax.
+ #}
+{%       if 'packetbeat' in _config %}
+{%         if _deprecated in _config['packetbeat'] %}
+{%           for _key in _config[_deprecated] %}
+{%             if _key in _config['packetbeat'][_deprecated] %}
+{%               set _ = _config[_deprecated].pop(_key) %}
+{%             else %}
+{%               set _ = _config['packetbeat'][_deprecated].update({_key: _config[_deprecated][_key]}) %}
+{%               set _ = _config[_deprecated].pop(_key) %}
+{%             endif %}
+{%           endfor %}
+{%         else %}
+{%           set _ = _config['packetbeat'].update({_deprecated: _config[_deprecated]}) %}
+{%           set _ = _config.pop(_deprecated) %}
+{%         endif %}
+{%       else %}
+{%         for _key in _config[_deprecated] %}
+{%           if ('packetbeat.' + _deprecated + '.' + _key) in _config %}
+{%             set _ = _config[_deprecated].pop(_key) %}
+{%           endif %}
+{%         endfor %}
+{%         set _ = _config.update({'packetbeat': {_deprecated: _config[_deprecated]}}) %}
 {%         set _ = _config.pop(_deprecated) %}
 {%       endif %}
 {%     endif %}

--- a/templates/etc/packetbeat/packetbeat.yml.j2
+++ b/templates/etc/packetbeat/packetbeat.yml.j2
@@ -28,12 +28,20 @@
 {%     if elasticbeats__version | version_compare('5.0-pre', '<') %}
 {%       for _section in [ 'interfaces', 'protocols', 'output', 'shipper', 'logging' ] %}
 {%         if _section in _beat['config'] %}
-{%           set _ = _config.update({_section: (_config[_section] | combine(_beat['config'][_section], recursive=True))}) %}
+{%           if _section in _config %}
+{%             set _ = _config.update({_section: (_config[_section] | combine(_beat['config'][_section], recursive=True))}) %}
+{%           else %}
+{%             set _ = _config.update({_section: _beat['config'][_section]}) %}
+{%           endif %}
 {%         endif %}
 {%       endfor %}
 {%     else %}
 {%       for _key in _beat['config'] %}
-{%         set _ = _config.update({_key: (_config[_key] | combine(_beat['config'][_key], recursive=True))}) %}
+{%         if _key in _config %}
+{%           set _ = _config.update({_key: (_config[_key] | combine(_beat['config'][_key], recursive=True))}) %}
+{%         else %}
+{%           set _ = _config.update({_key: _beat['config'][_key]}) %}
+{%         endif %}
 {%       endfor %}
 {%     endif %}
 {%   endif %}

--- a/templates/etc/topbeat/topbeat.yml.j2
+++ b/templates/etc/topbeat/topbeat.yml.j2
@@ -12,7 +12,11 @@
 {%   if _beat['name'] == 'topbeat' %}
 {%     for _section in [ 'input', 'output', 'shipper', 'logging' ] %}
 {%       if _section in _beat %}
-{%         set _ = _config.update({_section: (_config[_section] | combine(_beat['config'][_section], recursive=True))}) %}
+{%         if _section in _config %}
+{%           set _ = _config.update({_section: (_config[_section] | combine(_beat['config'][_section], recursive=True))}) %}
+{%         else %}
+{%           set _ = _config.update({_section: _beat['config'][_section]}) %}
+{%         endif %}
 {%       endif %}
 {%     endfor %}
 {%   endif %}

--- a/templates/lookup/elasticbeats__configdirs.j2
+++ b/templates/lookup/elasticbeats__configdirs.j2
@@ -1,9 +1,27 @@
-{% set _configdirs = [] %}
-{% for _beat in elasticbeats__beats|d([]) %}
-{%   if "" in _beat %}
-{%      set _ = _configdirs.extend(_beat["configdir"]) %}
+{% import 'lookup_macros.j2' as elasticbeats__lookup_macros with context %}
+{#
+ #  Add configuration directory to the list. The name is chosen as following:
+ #    - 'configdir' property if defined
+ #    - /etc/<name> where the beat name is taken from the 'name' property
+ #}
+{% macro add_configdir(_configdirs, _beat) %}
+{%   if 'configdir' in _beat %}
+{%      set _ = _configdirs.append(_beat['configdir']) %}
 {%   else %}
-{%      set _ = _configdirs.append("/etc/" + _beat["name"]) %}
+{%      set _ = _configdirs.append('/etc/' + _beat['name']) %}
+{%   endif %}
+{% endmacro %}
+{#
+ #  Return a list of the configuration directories of all beats defined in
+ #  `elasticbeats__beats`
+ #}
+{% set _configdirs = [] %}
+{% set _valid_beats = elasticbeats__lookup_macros.get_valid_beats() | from_yaml %}
+{% for _beat in elasticbeats__beats|d([]) %}
+{%   if _valid_beats and (_beat["name"] in _valid_beats) %}
+{%     set _ = add_configdir(_configdirs, _beat) %}
+{%   elif not _valid_beats %}
+{%     set _ = add_configdir(_configdirs, _beat) %}
 {%   endif %}
 {% endfor %}
-{{ _configdirs }}
+{{ _configdirs | to_yaml }}

--- a/templates/lookup/elasticbeats__configfiles.j2
+++ b/templates/lookup/elasticbeats__configfiles.j2
@@ -1,9 +1,27 @@
-{% set _configfiles = [] %}
-{% for _beat in elasticbeats__beats|d([]) %}
-{%   if "" in _beat %}
-{%      set _ = _configfiles.extend(_beat["configfile"]) %}
+{% import 'lookup_macros.j2' as elasticbeats__lookup_macros with context %}
+{#
+ #  Add configuration file to the list. The name is chosen as following:
+ #    - 'configfile' property if defined
+ #    - <name>.yml where the beat name is taken from the 'name' property
+ #}
+{% macro add_configfile(_configfiles, _beat) %}
+{%   if 'configfile' in _beat %}
+{%      set _ = _configfiles.append(_beat['configfile']) %}
 {%   else %}
-{%      set _ = _configfiles.append(_beat["name"] + ".yml") %}
+{%      set _ = _configfiles.append(_beat['name'] + '.yml') %}
+{%   endif %}
+{% endmacro %}
+{#
+ #  Return a list of the configuration files of all beats defined in
+ #  `elasticbeats__beats`
+ #}
+{% set _configfiles = [] %}
+{% set _valid_beats = elasticbeats__lookup_macros.get_valid_beats() | from_yaml %}
+{% for _beat in elasticbeats__beats|d([]) %}
+{%   if _valid_beats and (_beat["name"] in _valid_beats) %}
+{%     set _ = add_configfile(_configfiles, _beat) %}
+{%   elif not _valid_beats %}
+{%     set _ = add_configfile(_configfiles, _beat) %}
 {%   endif %}
 {% endfor %}
-{{ _configfiles }}
+{{ _configfiles | to_yaml }}

--- a/templates/lookup/elasticbeats__exec.j2
+++ b/templates/lookup/elasticbeats__exec.j2
@@ -1,0 +1,13 @@
+{% set _execs = [] %}
+{% for _beat in elasticbeats__beats|d([]) %}
+{%   if 'exec' in _beat %}
+{%      set _ = _execs.extend(_beat['exec']) %}
+{%   else %}
+{%      if elasticbeats__version | version_compare('5.0-pre', '>=') %}
+{%        set _ = _execs.append(_beat['name'] + '.sh') %}
+{%      else %}
+{%        set _ = _execs.append(_beat['name']) %}
+{%      endif %}
+{%   endif %}
+{% endfor %}
+{{ _execs }}

--- a/templates/lookup/elasticbeats__exec.j2
+++ b/templates/lookup/elasticbeats__exec.j2
@@ -1,5 +1,11 @@
-{% set _execs = [] %}
-{% for _beat in elasticbeats__beats|d([]) %}
+{% import 'lookup_macros.j2' as elasticbeats__lookup_macros with context %}
+{#
+ #  Add executable name to the list. The name is chosen as following:
+ #    - 'exec' property if defined
+ #    - <name> given in 'name' property for 3.x releases
+ #    - <name>.sh derived from the 'name' property for 5.x releases
+ #}
+{% macro add_exec(_execs, _beat) %}
 {%   if 'exec' in _beat %}
 {%      set _ = _execs.extend(_beat['exec']) %}
 {%   else %}
@@ -9,5 +15,17 @@
 {%        set _ = _execs.append(_beat['name']) %}
 {%      endif %}
 {%   endif %}
+{% endmacro %}
+{#
+ #  Return a list of the executable names of all beats defined in `elasticbeats__beats`
+ #}
+{% set _execs = [] %}
+{% set _valid_beats = elasticbeats__lookup_macros.get_valid_beats() | from_yaml %}
+{% for _beat in elasticbeats__beats|d([]) %}
+{%   if _valid_beats and (_beat["name"] in _valid_beats) %}
+{%     set _ = add_exec(_execs, _beat) %}
+{%   elif not _valid_beats %}
+{%     set _ = add_exec(_execs, _beat) %}
+{%   endif %}
 {% endfor %}
-{{ _execs }}
+{{ _execs | to_yaml }}

--- a/templates/lookup/elasticbeats__packages.j2
+++ b/templates/lookup/elasticbeats__packages.j2
@@ -1,9 +1,26 @@
-{% set _packages = [] %}
-{% for _beat in elasticbeats__beats|d([]) %}
-{%   if "packages" in _beat %}
-{%      set _ = _packages.append(_beat["packages"]) %}
+{% import 'lookup_macros.j2' as elasticbeats__lookup_macros with context %}
+{#
+ #  Add packages to the list. The name is chosen as following:
+ #    - 'packages' property if defined
+ #    - beat name given in 'name' property
+ #}
+{% macro add_packages(_packages, _beat) %}
+{%   if 'packages' in _beat %}
+{%      set _ = _packages.extend(_beat['packages']) %}
 {%   else %}
-{%      set _ = _packages.append([ _beat["name"] ]) %}
+{%      set _ = _packages.extend([_beat['name']]) %}
+{%   endif %}
+{% endmacro %}
+{#
+ #  Return a list of packages to install for all beats defined in `elasticbeats__beats`
+ #}
+{% set _packages = [] %}
+{% set _valid_beats = elasticbeats__lookup_macros.get_valid_beats() | from_yaml %}
+{% for _beat in elasticbeats__beats|d([]) %}
+{%   if _valid_beats and (_beat["name"] in _valid_beats) %}
+{%     set _ = add_packages(_packages, _beat) %}
+{%   elif not _valid_beats %}
+{%     set _ = add_packages(_packages, _beat) %}
 {%   endif %}
 {% endfor %}
-{{ _packages | to_nice_yaml }}
+{{ _packages | to_yaml }}

--- a/templates/lookup/elasticbeats__services.j2
+++ b/templates/lookup/elasticbeats__services.j2
@@ -1,9 +1,26 @@
-{% set _services = [] %}
-{% for _beat in elasticbeats__beats|d([]) %}
-{%   if "service" in _beat %}
-{%      set _ = _services.extend(_beat["service"]) %}
+{% import 'lookup_macros.j2' as elasticbeats__lookup_macros with context %}
+{#
+ #  Add service name to the list. The name is chosen as following:
+ #    - 'service' property if defined
+ #    - beat name given in 'name' property
+ #}
+{% macro add_service(_services, _beat) %}
+{%   if 'service' in _beat %}
+{%      set _ = _services.extend(_beat['service']) %}
 {%   else %}
-{%      set _ = _services.append(_beat["name"]) %}
+{%      set _ = _services.append(_beat['name']) %}
+{%   endif %}
+{% endmacro %}
+{#
+ #  Return a list of the service names of all beats defined in `elasticbeats__beats`
+ #}
+{% set _services = [] %}
+{% set _valid_beats = elasticbeats__lookup_macros.get_valid_beats() | from_yaml %}
+{% for _beat in elasticbeats__beats|d([]) %}
+{%   if _valid_beats and (_beat["name"] in _valid_beats) %}
+{%     set _ = add_service(_services, _beat) %}
+{%   elif not _valid_beats %}
+{%     set _ = add_service(_services, _beat) %}
 {%   endif %}
 {% endfor %}
-{{ _services }}
+{{ _services | to_yaml }}

--- a/templates/lookup/lookup_macros.j2
+++ b/templates/lookup/lookup_macros.j2
@@ -1,0 +1,14 @@
+{% macro get_valid_beats() %}
+{% set _beats = [] %}
+{#
+ #  Check if version string is reliable
+ #}
+{% if elasticbeats__apt_repo_source | search(elasticbeats__apt_repo_map[elasticbeats__version]) %}
+{%   if elasticbeats__version | version_compare('5.0-pre', '<') %}
+{%     set _ = _beats.extend(['filebeat', 'packetbeat', 'topbeat']) %}
+{%   else %}
+{%     set _ = _beats.extend(['filebeat', 'packetbeat', 'metricbeat']) %}
+{%   endif %}
+{% endif %}
+{{ _beats | to_yaml }}
+{% endmacro %}


### PR DESCRIPTION
This will add repository and configuration support for the upcoming Beats 5.0 release. It will further add support for `metricbeat` which is going to replace `topbeat`. 
